### PR TITLE
Fix the paths to GitHub pages content

### DIFF
--- a/instruction-material/bulk-rnaseq/00-reference-material.md
+++ b/instruction-material/bulk-rnaseq/00-reference-material.md
@@ -45,7 +45,7 @@ We recommend checking out the [Michigan State University Research Technology Sup
 #### View FastQC reports for samples from instruction
 
 We have generated FastQC reports for all samples we preprocess & quantify in class.
-They are tracked in this repository here: <https://github.com/jaclyn-taroni/2024-mdibl-fair/setup/bulk-rnaseq/QC/fastqc_reports> You can view an HTML version of an individual FASTQ file by adding the filename to the end of this URL in your browser <https://jaclyn-taroni.github.io/2024-mdibl-fair/setup/bulk-rnaseq/QC/fastqc_reports> For example, you'd navigate to the following URL for the `1_ATCACG_L001_R1_combined_fastqc.html` report: <https://jaclyn-taroni.github.io/2024-mdibl-fair/setup/bulk-rnaseq/QC/fastqc_reports/1_ATCACG_L001_R1_combined_fastqc.html>
+They are tracked in this repository here: <https://github.com/jaclyn-taroni/2024-mdibl-fair/setup/bulk-rnaseq/QC/fastqc_reports> You can view an HTML version of an individual FASTQ file by adding the filename to the end of this URL in your browser <https://jaclyn-taroni.github.io/2024-mdibl-fair/fastqc_reports> For example, you'd navigate to the following URL for the `1_ATCACG_L001_R1_combined_fastqc.html` report: <https://jaclyn-taroni.github.io/2024-mdibl-fair/fastqc_reports/1_ATCACG_L001_R1_combined_fastqc.html>
 
 
 ### MultiQC

--- a/instruction-material/bulk-rnaseq/01-fastp-salmon.md
+++ b/instruction-material/bulk-rnaseq/01-fastp-salmon.md
@@ -385,8 +385,8 @@ It should be noted that this is only appropriate for use with paired-end reads, 
 
 With this option enabled, Salmon will attempt to correct for the bias that occurs when using random hexamer priming (preferential sequencing of reads when certain motifs appear at the beginning); many RNA-seq experiments do use random hexamer priming!
 
-We know that this experiment shows evidence of random hexamer priming by looking at FastQC reports ([example](https://jaclyn-taroni.github.io/2024-mdibl-fair/setup/bulk-rnaseq/QC/fastqc_reports/5_ACAGTG_L001_R1_combined_fastqc.html#M4)).
-We don't cover FastQC here, but you can read more about it [in reference material we've prepared for you](https://jaclyn-taroni.github.io/2024-mdibl-fair/instruction-material/bulk-rnaseq/00-reference-material#fastqc).
+We know that this experiment shows evidence of random hexamer priming by looking at FastQC reports ([example](https://jaclyn-taroni.github.io/2024-mdibl-fair/fastqc_reports/5_ACAGTG_L001_R1_combined_fastqc.html#M4)).
+We don't cover FastQC here, but you can read more about it [in reference material we've prepared for you](00-reference-material.md#fastqc).
 
 You can read more about biases that arise from random hexamer priming in [Hansen *et al.* (2010)](https://doi.org/10.1093/nar/gkq224).
 
@@ -466,7 +466,7 @@ Type `q` to quit `less`!
 Of particular interest are the `summary`, `filtering_result`, and `duplication` fields, which can give you an idea of how much preprocessing (e.g., filtering, trimming) occurred and the sequence duplication rate (e.g., PCR duplicates or even short or very highly expressed transcripts; see [_Should I remove PCR duplicates from my RNA-seq data?_ from the UC Davis Genome Center](https://dnatech.genomecenter.ucdavis.edu/faqs/should-i-remove-pcr-duplicates-from-my-rna-seq-data/)), respectively.
 
 fastp also outputs HTML reports.
-You can see an example HTML fastp report for one of the samples in this experiment here:  <https://jaclyn-taroni.github.io/2024-mdibl-fair/setup/bulk-rnaseq/QC/fastp_reports/5_ACAGTG_L001_fastp.html>
+You can see an example HTML fastp report for one of the samples in this experiment here:  <https://jaclyn-taroni.github.io/2024-mdibl-fair/fastp_reports/5_ACAGTG_L001_fastp.html>
 
 If the vast majority of your reads were filtered out via this process, that would be cause for concern!
 


### PR DESCRIPTION
Only uploading the QC folder in the GitHub Action added in #5 necessitates updating paths to GitHub Pages content.