### PR TITLE
Use overwrite = TRUE for copying renv lockfile

### DIFF
--- a/instruction-material/machine-learning/scripts/list-required-r-packages.R
+++ b/instruction-material/machine-learning/scripts/list-required-r-packages.R
@@ -89,7 +89,8 @@ packages_df <- dplyr::bind_rows(
 # Copy over the renv lockfile for safe keeping
 file.copy(
   file.path(ml_instruction_dir, "renv.lock"),
-  file.path(components_dir, "renv.lock")
+  file.path(components_dir, "renv.lock"),
+  overwrite = TRUE
 )
 
 # Write out package table


### PR DESCRIPTION
Needed if re-running the ML R package listing script