### PR TITLE
Remove plots from ML upload directory

### DIFF
--- a/instruction-material/machine-learning/scripts/package-for-labcentral-upload.sh
+++ b/instruction-material/machine-learning/scripts/package-for-labcentral-upload.sh
@@ -34,6 +34,8 @@ Rscript -e "rmarkdown::render('01-ml-experimental-design.Rmd', clean = TRUE)"
 Rscript -e "rmarkdown::render('02-ml-biological-contexts.Rmd', clean = TRUE)"
 # Clean up *.nb.html files
 rm *.nb.html
+# Remove plots directory that was created when checking rendering
+rm -r plots
 # Fresh copy of notebooks
 cp ../*.Rmd .
 


### PR DESCRIPTION
The ML material now saves plots. When we check to make sure notebooks can render, we create the plots. This update adds a `rm` step to the shell script that prepares files for upload.